### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ A Model Context Protocol (MCP) server implementation that integrates with [WebSc
 - Account usage monitoring
 - Content sandboxing option - Wraps scraped content with security boundaries to help protect against prompt injection
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/webscraping-ai-webscraping-ai-mcp-server).
+
 ## Installation
 
 ### Running with npx


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/webscraping-ai-webscraping-ai-mcp-server).